### PR TITLE
Update nas2alb.sql

### DIFF
--- a/postprocessing.d/nas2alb.sql
+++ b/postprocessing.d/nas2alb.sql
@@ -216,6 +216,8 @@ CREATE TABLE str_shl (
 	gemshl character(32)
 );
 
+UPDATE ax_lagebezeichnungkatalogeintrag SET lage = substr(schluesselgesamt, 9) WHERE char_length(schluesselgesamt) = 12;
+
 INSERT INTO str_shl(strshl,strname,gemshl)
 	SELECT DISTINCT
 		to_char(alkis_toint(land),'fm00')||regierungsbezirk||to_char(alkis_toint(kreis),'fm00')||to_char(alkis_toint(gemeinde),'fm000')||'    '||trim(lage) AS strshl,


### PR DESCRIPTION
Bestimmte Kommunen liefern im Katalog "ax_lagebezeichnungkatalogeintrag" im "lage"-Feld 4- und 5-stellige Straßenschlüssel in der NAS-Datei (konkretes reales Beispiel:'02200' und '2200'). Aus mir nicht bekannten Gründen wird aus '2200' beim Import/Postprocessing '02200'.
Da unter anderem aus diesem Feld ein Primärschlüssel gebaut wird, ist das Script abegebrochen.
Fehlermeldung: psql:postprocessing.d/nas2alb.sql:227: FEHLER:  doppelter Schlüsselwert verletzt Unique-Constraint „str_shl_pkey“
DETAIL:  Schlüssel „(strshl)=(05916000    02200               )“ existiert bereits.)
