### PR TITLE
Grenzpunkt ohne Abmarkung (Marke)

### DIFF
--- a/alkis-ableitungsregeln.sql
+++ b/alkis-ableitungsregeln.sql
@@ -659,6 +659,7 @@ SELECT
 	CASE abmarkung_marke
 	WHEN 9600 THEN 3022
 	WHEN 9998 THEN 3024
+	WHEN 1700 THEN 3024
 	ELSE 3020
 	END AS signaturnummer,
 	o.advstandardmodell||o.sonstigesmodell||p.advstandardmodell||p.sonstigesmodell AS modell


### PR DESCRIPTION
Grenzpunkte die nicht Abgemarkt wurden weil es sich z.B. um eine
Hausecke handelt, werden nicht abgemarkt. Sie werden mit der Marke 1700
gekennzeichnet.
Beschreibung laut Ableitungsregeln: "Grenzpunkt, Punkt dauerhaft und gut
erkennbar festgelegt"