### PR TITLE
For files with -skipfailures use PG_USE_COPY=NO

### DIFF
--- a/alkisImport.py
+++ b/alkisImport.py
@@ -990,8 +990,9 @@ class alkisImportDlg(QDialog, alkisImportDlgBase):
 
                     if self.cbxSkipFailures.isChecked() or fn in checked:
                         args.append("-skipfailures")
-
-                    args.extend(["--config", "PG_USE_COPY", "YES" if self.cbxUseCopy.isChecked() else "NO"])
+                        args.extend(["--config", "PG_USE_COPY", "NO"])
+                    else:
+                        args.extend(["--config", "PG_USE_COPY", "YES" if self.cbxUseCopy.isChecked() else "NO"])
 
                     if gdal2:
                         args.extend(["-nlt", "CONVERT_TO_LINEAR", "-ds_transaction"])


### PR DESCRIPTION
For files where skip-failure is selected, PG_USE_COPY skips the whole transaction and not only individual objects that fail due to doublicate primary key.
This happens for example, if you add Alkis-Data for two cities, which have overlapping entries in the "katalogobjekte_bda.xml".

So PG_USE_COPY should only be used for files where skip-failures is not selected.