### PR TITLE
fix __future__ import SyntaxError

### DIFF
--- a/alkisImport.py
+++ b/alkisImport.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 # -*- coding: utf8 -*-
 
-""""""
+from __future__ import unicode_literals
+
 """
 ***************************************************************************
     alkisImport.py
@@ -19,7 +20,6 @@
 ***************************************************************************
 """
 
-from __future__ import unicode_literals
 from builtins import str
 from io import open
 


### PR DESCRIPTION
The __future__ import was after a string in the file, this led to
SyntaxError: from __future__ imports must occur at the beginning of the file