### PR TITLE
Update alkis-import.sh

### DIFF
--- a/alkis-import.sh
+++ b/alkis-import.sh
@@ -522,20 +522,23 @@ EOF
 		export DB
 		log() {
 			n=$(psql -X -t -c "SELECT count(*) FROM pg_catalog.pg_namespace WHERE nspname='${SCHEMA//\'/\'\'}'" "$DB")
-			n=${n//[	 ]}
+			n=${n//[	 
+]}
 			if [ $n -eq 0 ]; then
 				psql -X -q -c "CREATE SCHEMA \"${SCHEMA//\"/\"\"}\"" "$DB"
 			fi
 
 			n=$(psql -X -t -c "SELECT count(*) FROM pg_catalog.pg_namespace WHERE nspname='${SCHEMA//\'/\'\'}'" "$DB")
-			n=${n//[	 ]}
+			n=${n//[	 
+]}
 			if [ $n -eq 0 ]; then
 				echo "Schema $SCHEMA nicht erzeugt" >&2
 				exit 1
 			fi
 
 			n=$(psql -X -t -c "SELECT count(*) FROM pg_catalog.pg_tables WHERE schemaname='${SCHEMA//\'/\'\'}' AND tablename='alkis_importlog'" "$DB")
-			n=${n//[	 ]}
+			n=${n//[	 
+]}
 			if [ $n -eq 0 ]; then
 				psql -X -q -c "CREATE TABLE \"${SCHEMA//\"/\"\"}\".alkis_importlog(n SERIAL PRIMARY KEY, ts timestamp default now(), msg text)" "$DB"
 			fi
@@ -915,3 +918,5 @@ if [ "$src" == "error" ]; then
 	echo "WARNUNG: VERZEICHNIS $tmpdir WIRD NACH FEHLER NICHT GELÖSCHT."
 	exit 1
 fi
+
+sleep 1


### PR DESCRIPTION
Wenn in der Steuerungsdatei (*.lst) ein exit enthalten ist und die Verarbeitung nicht Zeitgesteuert (cron) sondern manuell ausgeführt wird, wartet das Script  am Ende auf eine Benutzereingabe und wird nicht korrekt beendet.
Ich habe dieses durch ein sleep am Ende der Datei beheben können.