### PR TITLE
Update alkis-import.sh

### DIFF
--- a/alkis-import.sh
+++ b/alkis-import.sh
@@ -793,8 +793,11 @@ EOF
 	"temp "*)
 		TEMP=${src#temp }
 		tmpdir=$TEMP
-		if ! [ -d "$TEMP" ]; then
+		if ! [ -d "$TEMP" ]
+		then
 			mkdir -p "$TEMP"
+		else
+			rm -f $TEMP/*
 		fi
 		continue
 		;;


### PR DESCRIPTION
Sollte das Temp-Verzeichnis bereits vorhanden sein, muss dieses leer sein, da eventuell durch einen Abbruch vom vorherigen Lauf noch Dateien vorhanden sein können, die zu einem Fehlverhalten führen können.