### PR TITLE
Update 41002.sql

### DIFF
--- a/postprocessing.d/1_ableitungsregeln/41002.sql
+++ b/postprocessing.d/1_ableitungsregeln/41002.sql
@@ -111,9 +111,9 @@ FROM (
 		coalesce(t.advstandardmodell||t.sonstigesmodell,o.advstandardmodell||o.sonstigesmodell) AS modell
 	FROM ax_industrieundgewerbeflaeche o
 	LEFT OUTER JOIN ap_pto t ON ARRAY[o.gml_id] <@ t.dientzurdarstellungvon AND t.art='FKT' AND t.endet IS NULL
-	LEFT OUTER JOIN ap_darstellung d ON ARRAY[o.gml_id] <@ d.dientzurdarstellungvon AND d.art='FKT' AND d.endet IS NULL
+	LEFT OUTER JOIN ap_darstellung d ON ARRAY[o.gml_id] <@ d.dientzurdarstellungvon AND d.endet IS NULL
 	WHERE o.endet IS NULL
-) AS i WHERE NOT text IS NULL;
+) AS i WHERE NOT text IS NULL AND signaturnummer != '6000';
 
 -- Industrie- und Gewerbefläche, Funktionssymbole
 INSERT INTO po_points(gml_id,thema,layer,point,drehwinkel,signaturnummer,modell)
@@ -146,7 +146,7 @@ FROM (
 		) AS modell
 	FROM ax_industrieundgewerbeflaeche o
 	LEFT OUTER JOIN ap_ppo p ON ARRAY[o.gml_id] <@ p.dientzurdarstellungvon AND p.art='FKT' AND p.endet IS NULL
-	LEFT OUTER JOIN ap_darstellung d ON ARRAY[o.gml_id] <@ d.dientzurdarstellungvon AND d.art='FKT' AND d.endet IS NULL
+	LEFT OUTER JOIN ap_darstellung d ON ARRAY[o.gml_id] <@ d.dientzurdarstellungvon AND d.endet IS NULL
 	WHERE o.endet IS NULL
 ) AS o
-WHERE NOT signaturnummer IS NULL;
+WHERE NOT signaturnummer IS NULL AND signaturnummer != '6000';


### PR DESCRIPTION
Die art = 'FKT' wird nicht für alle AP_Darstellungsobjekte gesetzt. Bei der Signaturnummer 6000 soll keine Darstellung erfolgen.

Behebung des Fehlers bei der Darstellung von Umspannwerken.
#78 