### PR TITLE
Anpassungen der Quittierungsdatei für den Kreis RE (GID7)

### DIFF
--- a/quittierung.py
+++ b/quittierung.py
@@ -136,6 +136,7 @@ else:
 
     for n in [
         './/portionskennung/AX_Portionskennung/profilkennung',
+        './/profilkennung',
         './/antragsnummer',
         './/auftragsnummer'
     ]:
@@ -155,7 +156,7 @@ else:
 
 erfolgreich = et.SubElement(q, "portionNBAErfolgreich", nsmap=nba.nsmap)
 
-portion = et.SubElement(erfolgreich, 'AX_Portion_Erfolgreich', attrib={"{%s}id" % nba.nsmap['gml']: gml_id}, nsmap=nba.nsmap)
+portion = et.SubElement(erfolgreich, 'AX_Portion_Erfolgreich', nsmap=nba.nsmap)
 portion.append(nba.find('.//portionskennung', nba.nsmap))
 
 pe = et.SubElement(portion, 'erfolgreich', nsmap=nba.nsmap)


### PR DESCRIPTION
Im Austausch mit den Kreis Recklinghausen wird eine Quittierungsdatei benötigt. Diese hat sich wohl in der Umstellung zur GID7 geändert. Es ist nicht viel was sich geändert hat aber ohne dieses Änderungen wird die Datei nicht vom System übernommen.
Ich habe die Änderungen mal als Patch vorbereitet. Die erstellte Quittierung ist danach auch mit den GID7 XSD Schema validierbar.  (Validiert gegen [https://repository.gdi-de.org/schemas/adv/nas/7.1/aaa.xsd](https://repository.gdi-de.org/schemas/adv/nas/7.1/aaa.xsd)).